### PR TITLE
do not enable UWB on first boot

### DIFF
--- a/service/java/com/android/server/uwb/UwbSettingsStore.java
+++ b/service/java/com/android/server/uwb/UwbSettingsStore.java
@@ -83,7 +83,7 @@ public class UwbSettingsStore {
      * Store the UWB settings toggle state.
      */
     public static final Key<Boolean> SETTINGS_TOGGLE_STATE =
-            new Key<>("settings_toggle", true);
+            new Key<>("settings_toggle", false);
 
     /******** Uwb shared pref keys ***************/
 
@@ -127,22 +127,6 @@ public class UwbSettingsStore {
     public void initialize() {
         Log.i(TAG, "Reading from store file: " + mAtomicFile.getBaseFile());
         readFromStoreFile();
-        // Migrate toggle settings from Android 12 to Android 13.
-        boolean isStoreEmpty;
-        synchronized (mLock) {
-            isStoreEmpty = mSettings.isEmpty();
-        }
-        if (isStoreEmpty) {
-            try {
-                boolean toggleEnabled =
-                        mUwbInjector.getSettingsInt(SETTINGS_TOGGLE_STATE_KEY_FOR_MIGRATION)
-                                == STATE_ENABLED_ACTIVE;
-                Log.i(TAG, "Migrate settings toggle from older release: " + toggleEnabled);
-                put(SETTINGS_TOGGLE_STATE, toggleEnabled);
-            } catch (Settings.SettingNotFoundException e) {
-                /* ignore */
-            }
-        }
         invokeAllListeners();
     }
 


### PR DESCRIPTION
SETTINGS_TOGGLE_STATE_KEY_FOR_MIGRATION (Settings.Global.UWB_ENABLED) setting is not set by default, but it might be set when system backup is restored, which can happen before migration code is executed.

Removing migration code prevents this scenario.

Change-Id: I5445b2c4db7c94e508e8bbf357e50f07595019a3